### PR TITLE
feat: Implement one-page website generator

### DIFF
--- a/TESTING_STRATEGY.md
+++ b/TESTING_STRATEGY.md
@@ -1,0 +1,51 @@
+# Testing Strategy for One-Page Website Generator
+
+This document outlines the conceptual testing strategy for the one-page website generator. These tests would ideally be automated using a UI testing framework.
+
+## 1. Core Drag-and-Drop Functionality
+
+### Test Case 1.1: Drag section from palette to valid container
+- **Description:** User drags a 'header' section from the palette and drops it into the 'header-container'.
+- **Expected Outcome:** The header section is successfully cloned and appended to the 'header-container'. The original section remains in the palette. The 'header-container' now contains the new header.
+
+### Test Case 1.2: Drag section from palette to invalid container
+- **Description:** User attempts to drag a 'header' section from the palette and drop it into the 'content-container'.
+- **Expected Outcome:** The drop is prevented. The 'content-container' remains unchanged. No new element is added.
+
+### Test Case 1.3: Replace header/footer
+- **Description:** User drops a 'header' section into the 'header-container' which already contains a header.
+- **Expected Outcome:** The old header is replaced by the new header. Only one header section is present in the 'header-container'. (Similar test for footer).
+
+### Test Case 1.4: Add multiple content sections
+- **Description:** User drags and drops three different 'content' sections into the 'content-container'.
+- **Expected Outcome:** All three content sections are successfully added to the 'content-container' in the order they were dropped.
+
+### Test Case 1.5: Reorder content sections
+- **Description:** User has three content sections in 'content-container'. User drags the first section and drops it between the second and third sections.
+- **Expected Outcome:** The order of content sections in 'content-container' is updated to reflect the new position.
+
+## 2. Section Palette Functionality
+
+### Test Case 2.1: Palette items remain after drag
+- **Description:** User drags a section from the palette and drops it onto a container.
+- **Expected Outcome:** The original section item remains visible and usable in the `section-palette`.
+
+## 3. Export Functionality
+
+### Test Case 3.1: Export simple page
+- **Description:** User creates a page with one header, one content section, and one footer. User clicks "Export HTML".
+- **Expected Outcome:** A textarea appears with HTML code. The code should contain the HTML structure of the header, content, and footer sections. Builder-specific attributes (like `draggable`, `data-section-category`) should be removed from the exported HTML. Basic inline styles should be present.
+
+### Test Case 3.2: Export page with multiple content sections
+- **Description:** User creates a page with one header, three content sections (in a specific order), and one footer. User clicks "Export HTML".
+- **Expected Outcome:** The exported HTML in the textarea should reflect the structure, including all three content sections in their correct order.
+
+### Test Case 3.3: Export empty page
+- **Description:** User has not dropped any sections and clicks "Export HTML".
+- **Expected Outcome:** The exported HTML should be a valid HTML document but with an empty body (or minimal structure if placeholder content is added by default to empty containers, which is not the current design).
+
+## 4. Basic UI Rendering
+
+### Test Case 4.1: Initial page load
+- **Description:** User opens `index.html`.
+- **Expected Outcome:** The section palette is visible and populated with all predefined section options. The header, content, and footer drop zones are visible and empty. The export button is visible.

--- a/content_about.html
+++ b/content_about.html
@@ -1,0 +1,4 @@
+<div class="content-option" data-type="content-about">
+    <h2>About Me</h2>
+    <p>This is a placeholder for a paragraph describing yourself. You can talk about your skills, experience, and passions here.</p>
+</div>

--- a/content_contact.html
+++ b/content_contact.html
@@ -1,0 +1,18 @@
+<div class="content-option" data-type="content-contact">
+    <h2>Contact Me</h2>
+    <form>
+        <div>
+            <label for="name">Name:</label>
+            <input type="text" id="name" name="name" placeholder="Your Name">
+        </div>
+        <div>
+            <label for="email">Email:</label>
+            <input type="email" id="email" name="email" placeholder="Your Email">
+        </div>
+        <div>
+            <label for="message">Message:</label>
+            <textarea id="message" name="message" placeholder="Your Message"></textarea>
+        </div>
+        <button type="submit">Send</button>
+    </form>
+</div>

--- a/content_gallery.html
+++ b/content_gallery.html
@@ -1,0 +1,8 @@
+<div class="content-option" data-type="content-gallery">
+    <h2>My Work</h2>
+    <div class="gallery-container">
+        <div class="gallery-item-placeholder">Item 1</div>
+        <div class="gallery-item-placeholder">Item 2</div>
+        <div class="gallery-item-placeholder">Item 3</div>
+    </div>
+</div>

--- a/footer_copyright.html
+++ b/footer_copyright.html
@@ -1,0 +1,3 @@
+<div class="footer-option" data-type="footer-copyright">
+    <p>&copy; 2023 Your Name</p>
+</div>

--- a/footer_social.html
+++ b/footer_social.html
@@ -1,0 +1,8 @@
+<div class="footer-option" data-type="footer-social">
+    <p>&copy; 2023 Your Name</p>
+    <ul>
+        <li><a href="#">Facebook</a></li>
+        <li><a href="#">Twitter</a></li>
+        <li><a href="#">LinkedIn</a></li>
+    </ul>
+</div>

--- a/header_nav.html
+++ b/header_nav.html
@@ -1,0 +1,12 @@
+<div class="header-option" data-type="header-nav">
+    <header>
+        <h1>My Portfolio</h1>
+        <nav>
+            <ul>
+                <li><a href="#">Home</a></li>
+                <li><a href="#">About</a></li>
+                <li><a href="#">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+</div>

--- a/header_simple.html
+++ b/header_simple.html
@@ -1,0 +1,3 @@
+<div class="header-option" data-type="header-simple">
+    <h1>My Portfolio</h1>
+</div>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dynamic Page Builder</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="script.js" defer></script>
+</head>
+<body>
+    <div id="header-container"></div>
+    <div id="content-container"></div>
+    <div id="footer-container"></div>
+    <div id="section-palette">
+        <div class="header-option" data-type="header-simple" data-section-category="header">
+            <h1>My Portfolio</h1>
+        </div>
+        <div class="header-option" data-type="header-nav" data-section-category="header">
+            <header>
+                <h1>My Portfolio</h1>
+                <nav>
+                    <ul>
+                        <li><a href="#">Home</a></li>
+                        <li><a href="#">About</a></li>
+                        <li><a href="#">Contact</a></li>
+                    </ul>
+                </nav>
+            </header>
+        </div>
+        <div class="content-option" data-type="content-about" data-section-category="content">
+            <h2>About Me</h2>
+            <p>This is a placeholder for a paragraph describing yourself. You can talk about your skills, experience, and passions here.</p>
+        </div>
+        <div class="content-option" data-type="content-gallery" data-section-category="content">
+            <h2>My Work</h2>
+            <div class="gallery-container">
+                <div class="gallery-item-placeholder">Item 1</div>
+                <div class="gallery-item-placeholder">Item 2</div>
+                <div class="gallery-item-placeholder">Item 3</div>
+            </div>
+        </div>
+        <div class="content-option" data-type="content-contact" data-section-category="content">
+            <h2>Contact Me</h2>
+            <form>
+                <div>
+                    <label for="name">Name:</label>
+                    <input type="text" id="name" name="name" placeholder="Your Name">
+                </div>
+                <div>
+                    <label for="email">Email:</label>
+                    <input type="email" id="email" name="email" placeholder="Your Email">
+                </div>
+                <div>
+                    <label for="message">Message:</label>
+                    <textarea id="message" name="message" placeholder="Your Message"></textarea>
+                </div>
+                <button type="submit">Send</button>
+            </form>
+        </div>
+        <div class="footer-option" data-type="footer-copyright" data-section-category="footer">
+            <p>&copy; 2023 Your Name</p>
+        </div>
+        <div class="footer-option" data-type="footer-social" data-section-category="footer">
+            <p>&copy; 2023 Your Name</p>
+            <ul>
+                <li><a href="#">Facebook</a></li>
+                <li><a href="#">Twitter</a></li>
+                <li><a href="#">LinkedIn</a></li>
+            </ul>
+        </div>
+    </div>
+
+    <div id="export-controls" style="text-align: center; margin: 20px;">
+        <button id="export-html-button">Export HTML</button>
+        <textarea id="exported-html" readonly style="display: none; width: 90%; height: 250px; margin-top: 15px; border: 1px solid #ccc; padding: 10px; box-sizing: border-box; background-color: #f9f9f9;"></textarea>
+    </div>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,312 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const paletteItems = document.querySelectorAll('#section-palette .header-option, #section-palette .content-option, #section-palette .footer-option');
+    const headerContainer = document.getElementById('header-container');
+    const contentContainer = document.getElementById('content-container');
+    const footerContainer = document.getElementById('footer-container');
+    const dropContainers = [headerContainer, contentContainer, footerContainer];
+
+    let draggedItem = null; // To store the actual element being dragged from the palette
+
+    // 1. Make section options draggable
+    paletteItems.forEach(item => {
+        item.setAttribute('draggable', 'true');
+
+        item.addEventListener('dragstart', (event) => {
+            // Store the dragged item itself
+            draggedItem = event.target; 
+            
+            // Store data-type and data-section-category
+            event.dataTransfer.setData('text/plain', event.target.dataset.type);
+            event.dataTransfer.setData('application/json', JSON.stringify({
+                type: event.target.dataset.type,
+                category: event.target.dataset.sectionCategory,
+                // outerHTML: event.target.outerHTML // Storing outerHTML for cloning later
+            }));
+            event.dataTransfer.effectAllowed = 'copy';
+            // Optional: Add a class for styling the item being dragged from the palette
+            event.target.classList.add('palette-item-dragging'); 
+        });
+
+        item.addEventListener('dragend', (event) => {
+            // Optional: Remove the styling class when dragging ends
+            event.target.classList.remove('palette-item-dragging');
+            draggedItem = null; 
+        });
+    });
+
+    // 2. Designate drop zones
+    dropContainers.forEach(container => {
+        container.addEventListener('dragover', (event) => {
+            event.preventDefault(); // Allow dropping
+            const draggedData = JSON.parse(event.dataTransfer.getData('application/json'));
+            const targetCategory = container.id.replace('-container', ''); // header, content, footer
+
+            if (draggedData.category === targetCategory) {
+                event.dataTransfer.dropEffect = 'copy';
+                container.classList.add('drag-over');
+            } else {
+                event.dataTransfer.dropEffect = 'none';
+            }
+        });
+
+        container.addEventListener('dragleave', (event) => {
+            container.classList.remove('drag-over');
+        });
+
+        container.addEventListener('drop', (event) => {
+            event.preventDefault();
+            container.classList.remove('drag-over');
+
+            const draggedData = JSON.parse(event.dataTransfer.getData('application/json'));
+            const targetCategory = container.id.replace('-container', ''); // header, content, footer
+
+            // Ensure the dragged item is from the palette and category matches
+            if (!draggedItem || draggedData.category !== targetCategory) {
+                console.warn('Drop rejected: Item not from palette or category mismatch.');
+                return;
+            }
+            
+            // Clone the original element from the palette
+            const clonedElement = draggedItem.cloneNode(true);
+
+            // Clean up palette-specific attributes and classes from the clone
+            clonedElement.classList.remove('header-option', 'content-option', 'footer-option', 'palette-item-dragging');
+            clonedElement.classList.add('dropped-section');
+            // Remove draggable attribute if items in containers are not meant to be immediately draggable
+            // clonedElement.removeAttribute('draggable'); // Decide later for reordering
+
+            // Logic for container types
+            if (targetCategory === 'header' || targetCategory === 'footer') {
+                // Replace existing content if any
+                container.innerHTML = ''; 
+                container.appendChild(clonedElement);
+            } else if (targetCategory === 'content') {
+                // Append to content container
+                container.appendChild(clonedElement);
+            }
+            
+            // After dropping, enable reordering for items in the content container
+            if (targetCategory === 'content') {
+                makeContentSectionsDraggable(container);
+            }
+             // Make sure the newly dropped header/footer is also re-draggable if it was a content item before (not applicable here, but good practice)
+            if (targetCategory === 'header' || targetCategory === 'footer') {
+                 clonedElement.setAttribute('draggable', 'false'); // Headers/Footers are not re-draggable for now
+            }
+
+
+            draggedItem = null; // Clear after successful drop
+        });
+    });
+
+    // 3. Reordering within #content-container
+    function makeContentSectionsDraggable(container) {
+        const items = container.querySelectorAll('.dropped-section');
+        items.forEach(item => {
+            // Only make content items draggable for reordering
+            if (item.dataset.sectionCategory === 'content') {
+                item.setAttribute('draggable', 'true');
+                item.classList.add('draggable-content'); // For specific styling/identification if needed
+            } else {
+                 item.setAttribute('draggable', 'false'); // Ensure headers/footers dropped are not re-draggable
+            }
+
+
+            // Remove previously attached listeners to avoid duplication
+            item.removeEventListener('dragstart', handleContentDragStart);
+            item.removeEventListener('dragend', handleContentDragEnd);
+
+            item.addEventListener('dragstart', handleContentDragStart);
+            item.addEventListener('dragend', handleContentDragEnd);
+        });
+    }
+    
+    let currentlyDraggedContentItem = null;
+
+    function handleContentDragStart(event) {
+        // Check if the item is actually draggable (is a content item)
+        if (event.target.getAttribute('draggable') !== 'true' || !event.target.classList.contains('dropped-section') || event.target.dataset.sectionCategory !== 'content') {
+            event.preventDefault();
+            return;
+        }
+        currentlyDraggedContentItem = event.target;
+        event.dataTransfer.setData('text/x-reorder-item-id', event.target.id || Math.random().toString(36).substr(2, 9)); // Use existing ID or generate one
+        if (!event.target.id) {
+            event.target.id = event.dataTransfer.getData('text/x-reorder-item-id');
+        }
+        event.dataTransfer.effectAllowed = 'move';
+        event.target.classList.add('content-item-dragging'); // Style for dragging content item
+        // Important: Stop propagation to prevent palette's dragstart if events bubble (though here it's a different set of items)
+        // event.stopPropagation(); 
+    }
+
+    function handleContentDragEnd(event) {
+        if (currentlyDraggedContentItem) {
+            currentlyDraggedContentItem.classList.remove('content-item-dragging');
+        }
+        currentlyDraggedContentItem = null;
+    }
+
+    contentContainer.addEventListener('dragover', (event) => {
+        event.preventDefault(); // Necessary for 'drop' to fire
+        if (event.dataTransfer.types.includes('text/x-reorder-item-id')) {
+             event.dataTransfer.dropEffect = 'move';
+            // Visual feedback for reordering
+            const draggingItem = currentlyDraggedContentItem;
+            if (!draggingItem) return;
+
+            const boundingBox = event.target.closest('.dropped-section');
+            if (boundingBox && boundingBox !== draggingItem) {
+                const rect = boundingBox.getBoundingClientRect();
+                const isAfter = event.clientY > rect.top + rect.height / 2;
+                if (isAfter) {
+                    boundingBox.parentNode.insertBefore(draggingItem, boundingBox.nextSibling);
+                } else {
+                    boundingBox.parentNode.insertBefore(draggingItem, boundingBox);
+                }
+            }
+        }
+    });
+    
+    contentContainer.addEventListener('drop', (event) => {
+        event.preventDefault();
+        // Check if this drop is for reordering an item already in the content container
+        const reorderItemId = event.dataTransfer.getData('text/x-reorder-item-id');
+        if (reorderItemId && currentlyDraggedContentItem && currentlyDraggedContentItem.id === reorderItemId) {
+            // The actual reordering logic is mostly handled by dragover for immediate feedback.
+            // Here we just finalize, e.g., remove any temporary styling.
+            // The currentlyDraggedContentItem is already in its new position due to DOM manipulation in dragover.
+            // No need to appendChild if it's a reorder.
+            // event.stopPropagation(); // Prevent palette drop logic if it's a reorder
+        } else if (event.dataTransfer.types.includes('application/json')) {
+            // This is a drop from the palette, handled by the generic drop listener.
+            // This specific 'drop' for contentContainer might need to ensure it doesn't double-process.
+            // However, the initial generic drop handler for dropContainers already covers this.
+            // To avoid double processing, we could check if the item was already appended.
+            // For now, the structure ensures that the generic one handles palette drops.
+        }
+        if (currentlyDraggedContentItem) {
+           currentlyDraggedContentItem.classList.remove('content-item-dragging');
+        }
+        currentlyDraggedContentItem = null;
+        // Ensure all content items are re-evaluated for draggability
+        makeContentSectionsDraggable(contentContainer);
+    });
+
+    // Initial call to make existing content items (if any, though there shouldn't be on load) draggable
+    makeContentSectionsDraggable(contentContainer);
+
+    // --- HTML Export Functionality ---
+    const exportHtmlButton = document.getElementById('export-html-button');
+    const exportedHtmlTextarea = document.getElementById('exported-html');
+
+    function cleanElementForExport(element) {
+        if (!element) return null;
+        const clone = element.cloneNode(true);
+
+        // Remove builder-specific attributes from the main cloned element
+        clone.removeAttribute('draggable');
+        clone.removeAttribute('data-type');
+        clone.removeAttribute('data-section-category');
+        clone.removeAttribute('id'); // Remove IDs that might have been generated for reordering
+
+        // Remove builder-specific classes
+        clone.classList.remove('drag-over', 'content-item-dragging', 'palette-item-dragging', 'draggable-content', 'header-option', 'content-option', 'footer-option');
+        // 'dropped-section' class is kept as it might be used for basic styling in the exported page
+
+        // Recursively clean children ONLY if they are also 'dropped-section' (which shouldn't happen with current structure)
+        // or if they have specific builder classes/attributes we know we want to remove.
+        // For now, let's focus on cleaning attributes from direct children if they are not standard HTML tags
+        // or if they are known to have builder attributes.
+        // This simplistic approach cleans the main dropped section and its immediate children if they also look like builder components.
+        
+        const elementsToCleanRecursively = clone.querySelectorAll('[draggable="true"], [data-type], [data-section-category], .drag-over, .content-item-dragging, .palette-item-dragging, .draggable-content');
+        elementsToCleanRecursively.forEach(child => {
+            child.removeAttribute('draggable');
+            child.removeAttribute('data-type');
+            child.removeAttribute('data-section-category');
+            child.removeAttribute('id');
+            child.classList.remove('drag-over', 'content-item-dragging', 'palette-item-dragging', 'draggable-content', 'header-option', 'content-option', 'footer-option');
+        });
+
+        // A more robust way for cleaning all descendants:
+        // clone.querySelectorAll('*').forEach(descendant => {
+        //     descendant.removeAttribute('draggable');
+        //     descendant.removeAttribute('data-type');
+        //     descendant.removeAttribute('data-section-category');
+        //     // Be careful with removing all IDs, some might be legitimate.
+        //     // descendant.removeAttribute('id'); 
+        //     descendant.classList.remove('drag-over', 'content-item-dragging', 'palette-item-dragging', 'draggable-content');
+        // });
+
+
+        return clone;
+    }
+
+    exportHtmlButton.addEventListener('click', () => {
+        let finalHtml = '';
+        let headerHtml = '';
+        let contentHtml = '';
+        let footerHtml = '';
+
+        // Get and clean header
+        const headerElement = headerContainer.querySelector('.dropped-section');
+        if (headerElement) {
+            const cleanedHeader = cleanElementForExport(headerElement);
+            if (cleanedHeader) headerHtml = cleanedHeader.outerHTML;
+        }
+
+        // Get and clean content sections
+        const contentElements = contentContainer.querySelectorAll('.dropped-section');
+        contentElements.forEach(el => {
+            const cleanedContentEl = cleanElementForExport(el);
+            if (cleanedContentEl) contentHtml += cleanedContentEl.outerHTML + '\n';
+        });
+
+        // Get and clean footer
+        const footerElement = footerContainer.querySelector('.dropped-section');
+        if (footerElement) {
+            const cleanedFooter = cleanElementForExport(footerElement);
+            if (cleanedFooter) footerHtml = cleanedFooter.outerHTML;
+        }
+        
+        const fullPageHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Exported Page</title>
+    <!-- Basic styling for dropped sections (optional) -->
+    <style>
+        body { font-family: sans-serif; margin: 0; padding: 0; background-color: #f0f0f0; }
+        .dropped-section { padding: 20px; margin-bottom: 10px; background-color: #fff; border: 1px solid #ddd; }
+        /* Add more generic styles for common elements if desired, e.g., h1, p, nav, form */
+        .dropped-section[data-type^="header-"] { background-color: #f8f9fa; padding: 20px; }
+        .dropped-section[data-type^="header-"] h1 { font-size: 2em; margin-top:0; }
+        .dropped-section[data-type="header-nav"] nav ul { list-style: none; padding: 0; display: flex; gap: 15px; }
+        .dropped-section[data-type="header-nav"] nav a { text-decoration: none; color: #007bff; }
+        .dropped-section[data-type="content-gallery"] .gallery-container { display: flex; flex-wrap: wrap; gap: 10px; }
+        .dropped-section[data-type="content-gallery"] .gallery-item-placeholder { width: 100px; height: 100px; background-color: #eee; border: 1px solid #ccc; display:flex; align-items:center; justify-content:center; }
+        .dropped-section[data-type="content-contact"] form div { margin-bottom: 10px; }
+        .dropped-section[data-type="content-contact"] form label { display: block; margin-bottom: 5px; }
+        .dropped-section[data-type="content-contact"] form input,
+        .dropped-section[data-type="content-contact"] form textarea { width: calc(100% - 16px); padding: 8px; border: 1px solid #ccc; border-radius: 4px; }
+        .dropped-section[data-type="content-contact"] form button { padding: 10px 15px; background-color: #28a745; color: white; border: none; border-radius: 4px; cursor: pointer; }
+        .dropped-section[data-type^="footer-"] { text-align: center; font-size: 0.9em; padding: 15px; background-color: #f8f9fa; }
+        .dropped-section[data-type="footer-social"] ul { list-style: none; padding: 0; display: flex; justify-content: center; gap: 15px; }
+        .dropped-section[data-type="footer-social"] ul li a { text-decoration: none; color: #007bff; }
+    </style>
+</head>
+<body>
+    ${headerHtml}
+    ${contentHtml}
+    ${footerHtml}
+</body>
+</html>`;
+
+        exportedHtmlTextarea.value = fullPageHtml;
+        exportedHtmlTextarea.style.display = 'block'; // Show the textarea
+        // Scroll to the textarea
+        exportedHtmlTextarea.scrollIntoView({ behavior: 'smooth' });
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,374 @@
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; /* Improved font */
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+    background-color: #f0f2f5; /* Subtle background for the page */
+    color: #333;
+}
+
+/* Main containers for dropped sections */
+#header-container, #content-container, #footer-container {
+    border: 2px dashed #adb5bd; /* Softer border color */
+    min-height: 100px;
+    margin: 15px; /* Increased margin */
+    padding: 15px; /* Increased padding for better spacing */
+    background-color: #ffffff; /* White background for content areas */
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05); /* Subtle shadow */
+    border-radius: 8px; /* Rounded corners */
+}
+
+#content-container {
+    flex-grow: 1; /* Allow content container to take available space */
+}
+
+/* Section Palette Styling */
+#section-palette {
+    border: 2px solid #dee2e6; /* Softer border */
+    min-height: 120px; 
+    margin: 15px;
+    padding: 20px; 
+    display: flex;
+    flex-wrap: wrap; 
+    gap: 20px; 
+    background-color: #ffffff; 
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    border-radius: 8px;
+}
+
+/* Styling for option items within the palette */
+.header-option, .content-option, .footer-option {
+    border: 1px dashed #007bff; /* Accent color for borders */
+    padding: 15px; /* Increased padding */
+    cursor: grab;
+    background-color: #f8f9fa; /* Lighter background */
+    text-align: center;
+    margin-bottom: 0; /* Gap is handled by #section-palette */
+    flex-basis: calc(33.333% - 40px); /* Adjust for gap and padding */
+    box-sizing: border-box; 
+    border-radius: 6px; /* Rounded corners for options */
+    transition: transform 0.2s ease, box-shadow 0.2s ease; /* Smooth transition for hover */
+}
+
+.header-option:hover, .content-option:hover, .footer-option:hover {
+    transform: translateY(-3px); /* Slight lift on hover */
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1); /* Shadow on hover */
+}
+
+/* Styling for the item being dragged from the palette */
+.palette-item-dragging {
+    border: 1px solid #007bff; 
+    cursor: grabbing; 
+    background-color: #e9ecef; 
+    opacity: 0.8; /* Slightly more opaque */
+    transform: scale(1.05); /* Slightly larger when dragging */
+}
+
+/* Styling for when a draggable item is over a drop target */
+.drag-over {
+    background-color: #e6f7ff; /* Light blue feedback */
+    border-style: solid;
+    border-color: #007bff; /* Accent color border */
+}
+
+/* General styling for sections once dropped into containers */
+.dropped-section {
+    padding: 25px; /* More padding */
+    margin-bottom: 20px; 
+    background-color: #ffffff; 
+    border: 1px solid #e9ecef; /* Softer border */
+    border-radius: 6px; /* Rounded corners */
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04); /* Subtle shadow */
+}
+/* Remove margin from the last dropped section in content to avoid double margin with footer */
+#content-container > .dropped-section:last-child {
+    margin-bottom: 0;
+}
+
+
+/* --- Specific styling for DROPPED sections --- */
+
+/* Headers */
+.dropped-section[data-type^="header-"] {
+    background-color: #f8f9fa; /* Slightly different background for headers */
+    padding: 20px;
+}
+.dropped-section[data-type^="header-"] h1 {
+    font-size: 2.2em;
+    color: #343a40;
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+.dropped-section[data-type="header-nav"] nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    gap: 20px; /* Increased gap */
+    justify-content: center; /* Center navigation links */
+}
+.dropped-section[data-type="header-nav"] nav a {
+    text-decoration: none;
+    color: #007bff; /* Accent color for links */
+    font-weight: 500;
+    padding: 5px 10px;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+}
+.dropped-section[data-type="header-nav"] nav a:hover {
+    background-color: #e9ecef;
+    text-decoration: none;
+}
+
+/* Content - About Me */
+.dropped-section[data-type="content-about"] h2 {
+    color: #495057;
+    margin-top: 0;
+    margin-bottom: 10px;
+}
+.dropped-section[data-type="content-about"] p {
+    line-height: 1.6;
+    color: #6c757d;
+}
+
+/* Content - Gallery */
+.dropped-section[data-type="content-gallery"] h2 {
+    color: #495057;
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+.dropped-section[data-type="content-gallery"] .gallery-container {
+    display: flex;
+    flex-wrap: wrap; /* Allow wrapping */
+    gap: 15px; /* Increased gap */
+    justify-content: flex-start; /* Align items to the start */
+    margin-top: 10px;
+}
+.dropped-section[data-type="content-gallery"] .gallery-container .gallery-item-placeholder {
+    width: 120px;  /* Larger placeholders */
+    height: 120px;
+    background-color: #e9ecef; /* Consistent light background */
+    border: 1px solid #ced4da; /* Softer border */
+    border-radius: 4px; /* Rounded corners */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9em;
+    color: #6c757d;
+}
+
+/* Content - Contact Form */
+.dropped-section[data-type="content-contact"] h2 {
+    color: #495057;
+    margin-top: 0;
+    margin-bottom: 15px;
+}
+.dropped-section[data-type="content-contact"] form div {
+    margin-bottom: 15px; /* Increased spacing */
+}
+.dropped-section[data-type="content-contact"] form label {
+    display: block;
+    font-size: 1em; /* Larger label */
+    margin-bottom: 5px; /* Space between label and input */
+    color: #495057;
+}
+.dropped-section[data-type="content-contact"] form input[type="text"],
+.dropped-section[data-type="content-contact"] form input[type="email"],
+.dropped-section[data-type="content-contact"] form textarea {
+    width: calc(100% - 24px); /* Full width minus padding and border */
+    padding: 10px;
+    font-size: 1em;
+    box-sizing: border-box;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    background-color: #fff; /* Ensure input background is white */
+}
+.dropped-section[data-type="content-contact"] form textarea {
+    min-height: 100px; /* Minimum height for textarea */
+    resize: vertical; /* Allow vertical resize */
+}
+.dropped-section[data-type="content-contact"] form button[type="submit"] {
+    background-color: #28a745; /* Green for submit */
+    color: white;
+    border: none;
+    cursor: pointer;
+    padding: 12px 20px; /* Larger button */
+    font-size: 1em;
+    border-radius: 4px;
+    transition: background-color 0.2s ease;
+}
+.dropped-section[data-type="content-contact"] form button[type="submit"]:hover {
+    background-color: #218838; /* Darker green on hover */
+}
+
+/* Footers */
+.dropped-section[data-type^="footer-"] {
+    text-align: center;
+    font-size: 0.95em; /* Slightly larger font */
+    padding: 20px; /* More padding */
+    background-color: #f8f9fa; /* Consistent with header background */
+    color: #6c757d;
+    margin-top: auto; /* Push footer to the bottom if content is short */
+}
+.dropped-section[data-type="footer-social"] ul {
+    list-style: none;
+    padding: 0;
+    margin: 10px 0 0 0; /* Add margin above the links */
+    display: flex;
+    justify-content: center;
+    gap: 25px; /* Increased gap for social links */
+}
+.dropped-section[data-type="footer-social"] ul li a {
+    text-decoration: none;
+    color: #007bff; /* Accent color */
+    font-weight: 500;
+}
+.dropped-section[data-type="footer-social"] ul li a:hover {
+    text-decoration: underline;
+}
+
+
+/* --- Styles for elements within PALETTE (Preview) --- */
+/* Keep palette item previews minimal but indicative */
+
+/* General styling for text in palette options */
+.header-option h1, .content-option h2, .footer-option p {
+    font-size: 1em; /* Smaller font for palette items */
+    margin: 5px 0;
+    color: #495057;
+}
+.header-option p, .content-option p {
+    font-size: 0.8em;
+    color: #6c757d;
+}
+
+/* Palette - Gallery item placeholders */
+.content-option[data-type="content-gallery"] .gallery-container {
+    display: flex;
+    gap: 3px; /* Smaller gap for palette */
+    justify-content: center;
+    margin-top: 3px;
+}
+.content-option[data-type="content-gallery"] .gallery-item-placeholder {
+    border: 1px dashed #adb5bd; /* Softer border */
+    padding: 5px 3px; /* Smaller padding */
+    font-size: 0.7em; /* Smaller font */
+    background-color: #e9ecef; /* Light background */
+    border-radius: 2px;
+}
+
+/* Palette - Contact form elements (minimal styling) */
+.content-option[data-type="content-contact"] form div {
+    margin-bottom: 3px;
+    text-align: left;
+}
+.content-option[data-type="content-contact"] form label {
+    display: block;
+    font-size: 0.75em; /* Smaller font */
+    margin-bottom: 1px;
+}
+.content-option[data-type="content-contact"] form input,
+.content-option[data-type="content-contact"] form textarea,
+.content-option[data-type="content-contact"] form button {
+    width: calc(100% - 8px); 
+    padding: 2px;
+    font-size: 0.75em;
+    box-sizing: border-box;
+    border: 1px solid #ced4da;
+    border-radius: 2px;
+}
+.content-option[data-type="content-contact"] form button {
+    background-color: #5cb85c;
+    color: white;
+    border: none;
+    cursor: default; /* No pointer cursor in palette */
+    margin-top: 3px;
+}
+
+/* Palette - Nav links */
+.header-option[data-type="header-nav"] nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 3px 0 0 0;
+    display: flex;
+    justify-content: center;
+    gap: 5px; /* Smaller gap */
+}
+.header-option[data-type="header-nav"] nav ul li a {
+    text-decoration: none;
+    color: #007bff;
+    font-size: 0.8em; /* Smaller font */
+}
+
+/* Palette - Social links */
+.footer-option[data-type="footer-social"] ul {
+    list-style: none;
+    padding: 0;
+    margin: 3px 0 0 0;
+    display: flex;
+    justify-content: center;
+    gap: 5px; /* Smaller gap */
+}
+.footer-option[data-type="footer-social"] ul li a {
+    text-decoration: none;
+    color: #007bff;
+    font-size: 0.8em; /* Smaller font */
+}
+
+/* Styling for item being reordered within content container */
+.content-item-dragging {
+    opacity: 0.6;
+    border: 2px dashed #007bff; /* Highlight while dragging */
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+}
+
+/* Export Controls Styling */
+#export-controls {
+    text-align: center;
+    padding: 20px;
+    background-color: #f8f9fa; /* Light background for the controls area */
+    margin: 15px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+#export-html-button {
+    background-color: #007bff; /* Primary button color */
+    color: white;
+    border: none;
+    padding: 12px 25px; /* Generous padding */
+    font-size: 1.1em; /* Larger font */
+    border-radius: 6px; /* Rounded corners */
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.1s ease;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1); /* Subtle shadow */
+}
+
+#export-html-button:hover {
+    background-color: #0056b3; /* Darker on hover */
+    transform: translateY(-1px); /* Slight lift on hover */
+}
+
+#export-html-button:active {
+    transform: translateY(0px); /* Click feedback */
+}
+
+#exported-html {
+    width: calc(100% - 40px); /* Full width minus padding */
+    max-width: 800px; /* Max width for readability */
+    height: 300px; /* Increased height */
+    margin: 20px auto 0 auto; /* Centered with margin top */
+    padding: 15px;
+    box-sizing: border-box;
+    border: 1px solid #ced4da; /* Softer border */
+    border-radius: 6px;
+    background-color: #fff; /* White background */
+    font-family: 'Courier New', Courier, monospace; /* Monospace font for code */
+    font-size: 0.9em;
+    line-height: 1.4;
+    white-space: pre; /* Preserve whitespace and newlines */
+    overflow: auto; /* Add scrollbars if content overflows */
+    display: none; /* Initially hidden - JS will show it */
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+}


### PR DESCRIPTION
This project creates an HTML, CSS, and JavaScript based one-page website generator.

Key features implemented:
1.  **Basic Structure:** I set up `index.html`, `style.css`, and `script.js`.
2.  **Reusable Sections:**
    *   I created multiple HTML snippets for header, content (About, Gallery, Contact), and footer sections.
3.  **Section Palette:** I implemented a UI (`#section-palette`) in `index.html` to display available sections.
4.  **Drag-and-Drop:**
    *   I enabled dragging sections from the palette to designated header, content, and footer containers.
    *   I implemented cloning of sections (palette options remain).
    *   Header/Footer containers accept one section (replace if existing).
    *   Content container accepts multiple sections.
    *   I enabled reordering of sections within the content container.
5.  **Styling:**
    *   I added CSS for the builder interface (palette, containers).
    *   I styled the individual section options in the palette.
    *   I styled the dropped sections for a presentable look on the preview.
    *   I included visual feedback for drag operations (e.g., highlighting drop targets).
6.  **HTML Export:**
    *   I added an "Export HTML" button.
    *   JavaScript generates a clean HTML document of the user-created page.
    *   Builder-specific attributes are removed from the exported HTML.
    *   Basic inline CSS is included in the exported HTML for presentation.
    *   The generated HTML is displayed in a textarea.
7.  **Testing Strategy:** I created `TESTING_STRATEGY.md` outlining conceptual UI tests for core functionalities.

The generator allows you to visually construct a one-page website and export the resulting HTML.